### PR TITLE
Studio-ZQM: do not rethrow exception and fail, but log instead.  

### DIFF
--- a/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQServer.java
+++ b/mmstudio/src/main/java/org/micromanager/internal/zmq/ZMQServer.java
@@ -213,7 +213,7 @@ public class ZMQServer extends ZMQSocketWrapper {
                            apiClasses_.add(Class.forName(packageName + '.' + file.getName().
                                    substring(0, file.getName().length() - 6)));
                         } catch (ClassNotFoundException ex) {
-                           throw new RuntimeException("Problem loading class:" + file.getName());
+                           studio_.logs().logError("Failed to load class: " + file.getName());
                         }
                      }
                   }


### PR DESCRIPTION
This exception can very easily happen with certain run-time configurations and will be mostly innocuous and difficult to work around otherwise.